### PR TITLE
Add initial proof of concept files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Good Docs Code of Conduct - DRAFT PROOF OF CONCEPT
+
+This document is currently a work in progress.
+
+In October 2020, we created a Code of Conduct committee to draft the first
+Code of Conduct file and create a process for handling conduct reports. If
+you would like to join the Code of Conduct committee, join our community
+Slack and mention your interest in the `#general` channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to the Good Docs - DRAFT PROOF OF CONCEPT
+
+We’d love your help.
+
+* Have you noticed something that could be improved?
+* Want to share your tech writing expertise?
+* Do you have material you’d like to integrate into our baseline?
+* Do you know of research which should be referenced?
+* Something else?
+
+Please do reach out to us with your ideas.
+
+## Contact us
+
+* Slack: [https://thegooddocs.slack.com/](https://thegooddocs.slack.com/)
+* Email list: [https://groups.io/g/thegooddocsproject/](https://groups.io/g/thegooddocsproject/)
+
+## About contributing
+
+### Licenses
+
+By contributing to this project we expect you to agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution, and agree to do so under the [open licenses](licenses) we use.
+
+### Contributing
+
+You can improve our documentation by submitting a pull request to our [Github templates repo](https://github.com/thegooddocsproject/templates). Here is [how](https://guides.github.com/activities/hello-world/).
+
+For all but minor typos, it is s a good idea to discuss your proposed changes with us before submitting a pull request.
+
+1. Create an issue in the [github  tracker](https://github.com/thegooddocsproject/templates/issues).
+2. Be as specific as you can in the scope of work within the issue. Be sure to include the "why" for considering the work.
+3. Share the link to the bug on the #general channel in our [Slack instance](https://thegooddocs.slack.com) to get a review of your idea.
+4. Once folks agree on your proposed changes you can begin work.
+
+### Issue tracker
+
+We track outstanding work in our [github  tracker](https://github.com/thegooddocsproject/templates/issues). To keep our issue tracker manageable, we prefer you discuss suggestions or issues in one of our forums, typically our email list, before adding an issue to the tracker.
+
+### Style guide
+
+We use the [Google Style Guide](http://google.github.io/styleguide/) and American spelling, as per the [Merriam-Webster Online](https://www.merriam-webster.com/)  dictionary. If you’re used to working with such reference books, that’s great; if not, please contribute anyway, a tech writer will likely update your contribution later.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+> __ALL Pull-Requests require an associated [Issue](https://github.com/thegooddocsproject/templates/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) as documented in [How to contribute](https://github.com/thegooddocsproject/templates/blob/master/CONTRIBUTING.md#contributing).__
+
+## Purpose / why
+
+> _**Replace this text** - Restate the purpose/justification of this work and include links to the issue inside of the purpose/why._
+
+## What changes were made?
+
+> _**Replace this text** - State clearly the direct additions or modifications made in this change-request._
+
+## Verification
+
+> _**Replace this text** - Document the details that help a reviewer understand what steps or actions should be taken in-order to verify the work is completed and satisfies the initial scope of work._
+
+---
+
+## Checklist
+
+> __Pull-request reviewer__ should ensure the following
+
+* [ ] Are issues linked correctly?
+* [ ] Is this PR labeled correctly?
+* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
+* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
+* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
+* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# .github
+# The Good Docs - DRAFT PROOF OF CONCEPT
+
+Welcome to the Good Docs project! If you are an open-source developer looking
+for high-quality documentation templates to improve and enhance your project's
+docs, you've come to the right place!
+
+
+## What is the Good Docs project?
+
+The goal of the Good Docs is to improve the overall quality of documentation in
+open source. To achieve this goal, we've assembled a community of technical
+writers and developers to create high-quality templates for a variety of
+documentation needs. Visit the [Good Docs website](https://thegooddocsproject.dev/)
+for more information.


### PR DESCRIPTION
This PR adds a few initial files for the .github repository proof of concept:

- Code of Conduct (still pending)
- Contributing (based on the one in the `templates` repo)
- Pull request template (based on  the one in the `templates` repo)